### PR TITLE
Rollback autosklearn to version 0.12.1

### DIFF
--- a/components/platiagro-notebook-servers/base/requirements-common.txt
+++ b/components/platiagro-notebook-servers/base/requirements-common.txt
@@ -31,6 +31,7 @@ tables==3.6.1
 vincent==0.4.4
 xlrd==2.0.1
 PyPDF4==1.27.0
+black==21.7b0
 
 
 # Extra packages, required by PlatIAgro

--- a/components/platiagro-notebook-servers/base/requirements-common.txt
+++ b/components/platiagro-notebook-servers/base/requirements-common.txt
@@ -63,7 +63,7 @@ rank-bm25==0.2.1
 
 # AutoML
 # https://github.com/platiagro/tasks/tree/main/tasks/automl-classifier
-auto-sklearn==0.12.7
+auto-sklearn==0.12.1
 category-encoders==2.2.2
 
 # Transformation Graph


### PR DESCRIPTION
Fix training errors observed on very long executions:
FileNotFoundError: [Errno 2] No such file or directory:
'/tmp/autosklearn_tmp_ea03714a-1643-11ec-8016-f26d25c074c8/distributed.log'