### PR TITLE
Sets dask and distributed versions compatible with autosklearn

### DIFF
--- a/components/platiagro-notebook-servers/base/requirements-common.txt
+++ b/components/platiagro-notebook-servers/base/requirements-common.txt
@@ -9,7 +9,8 @@ bokeh==2.3.1
 #Bottleneck==1.3.2 Could not build wheels for Bottleneck which use PEP 517 and cannot be installed directly
 cloudpickle==1.6.0
 cython==0.29.22
-dask==2021.4.0
+dask<2021.07
+distributed>=2.2.0,<2021.07
 dill==0.3.3
 h5py==3.2.1
 ipympl==0.7.0


### PR DESCRIPTION
Fix ImportError: cannot import name 'dumps_msgpack' from 'distributed.protocol.core'